### PR TITLE
Add `success?` method to A3rt::Talk::Response

### DIFF
--- a/lib/a3rt/talk/response.rb
+++ b/lib/a3rt/talk/response.rb
@@ -12,5 +12,10 @@ module A3rt::Talk
     def least_perplex
       results.min_by(&:perplexity)
     end
+
+    # @see https://a3rt.recruit-tech.co.jp/product/talkAPI/
+    def success?
+      status == 0
+    end
   end
 end

--- a/spec/a3rt/talk/response_spec.rb
+++ b/spec/a3rt/talk/response_spec.rb
@@ -10,12 +10,33 @@ describe A3rt::Talk::Response do
     }
   end
 
+  let(:raw_failure_response) do
+    {
+      'status' => 1001,
+      'message' => 'apikey not found',
+    }
+  end
+
   describe '#least_perplex' do
     let(:response) { A3rt::Talk::Response.new(raw_success_response) }
     subject { response.least_perplex }
 
     it 'returns the result with least perplex' do
       expect(subject).to have_attributes(reply: 'test2', perplexity: 0.2)
+    end
+  end
+
+  describe '#success?' do
+    subject { response.success? }
+
+    context 'when the response status is 0' do
+      let(:response) { A3rt::Talk::Response.new(raw_success_response) }
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when the response status is not 0' do
+      let(:response) { A3rt::Talk::Response.new(raw_failure_response) }
+      it { is_expected.to be_falsy }
     end
   end
 end


### PR DESCRIPTION
Add `A3rt::Talk::Response#success?` method to judge if a request is succeeded.
This method returns true only when the status field equals 0 (The list of status codes can be seen here: https://a3rt.recruit-tech.co.jp/product/talkAPI/).

This method is useful to implement error handling for wrapper libraries (such as ruboty-a3rt-talk).